### PR TITLE
Make ball colors more distinctive for red/green color-blindness

### DIFF
--- a/src/Render.ts
+++ b/src/Render.ts
@@ -46,8 +46,8 @@ export default class Renderer {
 
     rgrd.addColorStop(0.1, tinycolor(body.color).toRgbString());
     rgrd.addColorStop(1, tinycolor(body.color).spin(50).darken(20).toRgbString());
-    lgrd.addColorStop(0,tinycolor(body.color).darken(100).setAlpha(0.7).toRgbString());
-    lgrd.addColorStop(1,tinycolor(body.color).lighten(100).setAlpha(0.7).toRgbString());
+    lgrd.addColorStop(0,tinycolor(body.color).darken(50).setAlpha(0.7).toRgbString());
+    lgrd.addColorStop(1,tinycolor(body.color).lighten(80).setAlpha(0.7).toRgbString());
 
     this.ctx.fillStyle=rgrd;
     this.ctx.beginPath()

--- a/src/Universals.ts
+++ b/src/Universals.ts
@@ -8,8 +8,8 @@ export default {
   bounds,
   teamColors: {
     "boccino": 'white',
-    "red":  tinycolor('red').toRgbString(),
-    "green": tinycolor('green').toRgbString(),
+    "red":  tinycolor('#ff2424').toRgbString(),
+    "green": tinycolor('#5af2b7').toRgbString(),
   },
   launchPos: new Victor(80,bounds.y-80)
 }


### PR DESCRIPTION
Great game!

While playing this, I was struggling to tell the difference between the red and green bocce balls (I have red/green color-blindess).

I know red and green are traditional bocce colors, so I left them red and green, and just adjusted the hues and lightness to make them more distinctive. You could probably make more dramatic changes using patterns or something but this was a quick fix that seemed to work well for me.

**Before:**
![image](https://user-images.githubusercontent.com/1256329/84583212-53d6c200-adc4-11ea-8371-4bdd1033e152.png)

**After:**
![image](https://user-images.githubusercontent.com/1256329/84583223-6224de00-adc4-11ea-9e22-44b2911a8bab.png)

(Note: I didn't commit the bundled js since my version of webpack was adding a bunch of other changes... let me know if you want that included too.)